### PR TITLE
Reconcile with latest changes in robotlegs-framework

### DIFF
--- a/src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap.as
+++ b/src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap.as
@@ -7,9 +7,9 @@
 
 package robotlegs.bender.extensions.signalCommandMap.api
 {
-import robotlegs.bender.extensions.commandMap.dsl.ICommandMapper;
-import robotlegs.bender.extensions.commandMap.dsl.ICommandMappingFinder;
-import robotlegs.bender.extensions.commandMap.dsl.ICommandUnmapper;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandMapper;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandMappingFinder;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandUnmapper;
 
 public interface ISignalCommandMap
 {

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap.as
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap.as
@@ -12,11 +12,11 @@ import flash.utils.Dictionary;
 import org.osflash.signals.ISignal;
 import org.swiftsuspenders.Injector;
 
-import robotlegs.bender.extensions.commandMap.api.ICommandMap;
-import robotlegs.bender.extensions.commandMap.dsl.ICommandMapper;
-import robotlegs.bender.extensions.commandMap.dsl.ICommandMappingFinder;
-import robotlegs.bender.extensions.commandMap.dsl.ICommandUnmapper;
-import robotlegs.bender.extensions.commandMap.api.ICommandTrigger;
+import robotlegs.bender.extensions.commandCenter.api.ICommandCenter;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandMapper;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandMappingFinder;
+import robotlegs.bender.extensions.commandCenter.dsl.ICommandUnmapper;
+import robotlegs.bender.extensions.commandCenter.api.ICommandTrigger;
 
 import robotlegs.bender.extensions.signalCommandMap.api.ISignalCommandMap;
 
@@ -31,13 +31,13 @@ public class SignalCommandMap implements ISignalCommandMap
 
     private var _injector:Injector;
 
-    private var _commandMap:ICommandMap;
+    private var _commandMap:ICommandCenter;
 
     /*============================================================================*/
     /* Constructor                                                                */
     /*============================================================================*/
 
-    public function SignalCommandMap(injector:Injector, commandMap:ICommandMap)
+    public function SignalCommandMap(injector:Injector, commandMap:ICommandCenter)
     {
         _injector = injector;
         _commandMap = commandMap;

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.as
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.as
@@ -14,8 +14,8 @@ import org.osflash.signals.ISignal;
 import org.osflash.signals.Signal;
 import org.swiftsuspenders.Injector;
 
-import robotlegs.bender.extensions.commandMap.api.ICommandMapping;
-import robotlegs.bender.extensions.commandMap.api.ICommandTrigger;
+import robotlegs.bender.extensions.commandCenter.api.ICommandMapping;
+import robotlegs.bender.extensions.commandCenter.api.ICommandTrigger;
 import robotlegs.bender.framework.impl.applyHooks;
 import robotlegs.bender.framework.impl.guardsApprove;
 


### PR DESCRIPTION
The SignalCommandMap is broken against the latest from robotlegs-framework. Some names have changed, pointedly the repackaging of the "commandMap" to the "commandCenter". This patch updates the repository to match the latest name changes in robotlegs-framework.
