### PR TITLE
Inject the triggering-signal to the command if so requested.

### DIFF
--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.as
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.as
@@ -103,6 +103,7 @@ public class SignalCommandTrigger implements ICommandTrigger
         for each (var mapping:ICommandMapping in mappings)
         {
 	        mapSignalValues(signal.valueClasses, valueObjects);
+            mapSignal(signal);
             if (guardsApprove(mapping.guards, _injector))
             {
                 _once && removeMapping(mapping);
@@ -113,10 +114,22 @@ public class SignalCommandTrigger implements ICommandTrigger
                 command.execute();
             }
 	        unmapSignalValues(signal.valueClasses, valueObjects);
+            unmapSignal();
         }
 
         if ( _once )
             removeSignal(commandClass );
+    }
+
+    private function mapSignal(signal:ISignal):void {
+        unmapSignal();
+        _injector.map(ISignal, 'trigger').toValue(signal);
+    }
+
+    private function unmapSignal():void {
+        const hasMapping: Boolean = _injector.hasDirectMapping(ISignal, 'trigger');
+        if(hasMapping)
+            _injector.unmap(ISignal, 'trigger');
     }
 
     protected function mapSignalValues(valueClasses:Array, valueObjects:Array):void {


### PR DESCRIPTION
On cases when the instance of the triggering signal is necessary inside the Command it can now be requested it's injection by  using the [Inject(name="trigger")] tag in the Command as so:

```
[Inject(name="trigger")]
public var triggerSignal:ISignal;
```

This was mainly created to obtain the actual QualifiedClassName of the trigger (ISignal). But many other uses can be also applied.
